### PR TITLE
Remove 'debug' setting affecting other plugins

### DIFF
--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -17,7 +17,6 @@ func! <SID>ToggleGoErrorFolding()
     normal zR
     echo "go error folding [off]"
   endif
-  set debug=msg
 endfunc
 
 func! GetGoErrorFold(lnum)


### PR DESCRIPTION
As an example it affects vim-traces, it starts to throw errors on empty lines.